### PR TITLE
Make the script work for other editors than vim, .... because EMACS RULES ;P

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # fzstd
 
-Fuzzy find using `fzf` to search a string from `STDIN` and open `vim` at the right line.
+Fuzzy find using `fzf` to search a string from `STDIN` and open your favorite editor at the right line.
 
 Useful to find a search term and immediately get the surrounding context without using grep -A -B.
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,6 @@ Example usage:
 hashcat.bin --help | fzstd
 ```
 
-Requires fzf and vim (or another editor, references by the `EDITOR` environment variable).
+Requires fzf and vim (or another editor, referenced by the `EDITOR` environment variable).
 
 ![](https://github.com/doomerhunter/fzstd/blob/main/fzstd.gif)

--- a/README.md
+++ b/README.md
@@ -10,6 +10,6 @@ Example usage:
 hashcat.bin --help | fzstd
 ```
 
-Requires fzf and vim
+Requires fzf and vim (or another editor, references by the `EDITOR` environment variable).
 
 ![](https://github.com/doomerhunter/fzstd/blob/main/fzstd.gif)

--- a/fzstd
+++ b/fzstd
@@ -16,7 +16,7 @@ selected=$(awk '{print NR " " $0}' "$temp_file" | fzf | awk '{print $1}')
 # Edit the temporary file at the selected line, if any
 if [[ ! -z $selected ]]; then
   # Explicitly redirect vim's stdin from the terminal
-  < /dev/tty vim +"$selected" "$temp_file"
+  < /dev/tty ${EDITOR:-vim} +"$selected" "$temp_file"
   echo "Edited content saved to $temp_file"
 else
   echo "No selection made."


### PR DESCRIPTION
Your trick to open `vim` at a given line also works for `emacs` fortunately:

```
< /dev/tty ${EDITOR:-vim} +"$selected" "$temp_file"
```

So I replaced it with `EDITOR` env var. By default `vim` to comply with your initial wishes (although I'm an emacs user ;P). :joke: